### PR TITLE
Correction sur le prefab rightcontroller

### DIFF
--- a/Assets/5_Prefabs/modèle3D_Salon/Prefabs_InsideRoom/ModernOfficeInterior/About/Scripts.meta
+++ b/Assets/5_Prefabs/modèle3D_Salon/Prefabs_InsideRoom/ModernOfficeInterior/About/Scripts.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b5ddf609e2041ed458c3af8d6f626137
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/5_Prefabs/modèle3D_Salon/_SNAPS_PrototypingAssets/About/Scripts.meta
+++ b/Assets/5_Prefabs/modèle3D_Salon/_SNAPS_PrototypingAssets/About/Scripts.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 1f545d0b97525424eb52e33ae79e86cb
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Prefabs/GameObjects_TestScene.meta
+++ b/Assets/Prefabs/GameObjects_TestScene.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 5b15f062f69873746a92c9e6b0590f77
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Resources/cozy-lake.meta
+++ b/Assets/Resources/cozy-lake.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b299f93b1a31f574fa1f0660dc018881
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Des modifications avaient été faites sur l'instance du prefab au lieu du prefab; d'où le bug.
La fonction deleteWhiteboardTool a été remise sur le bouton du radialMenuMarker de la manette droite.